### PR TITLE
Fix typo in "note.html" layout

### DIFF
--- a/note-organizer/_layouts/note.html
+++ b/note-organizer/_layouts/note.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="container" id="main-container">
     <header class="note-section card card-body bg-light">
-        <h1>{{ page.note_subject_name }} ({{ page.note_subject_type | downcase }}, semestr  {{ page.note_semester }})</h1>
+        <h1>{{ page.note_subject_name }} ({{ page.note_subject_type | downcase }}, semester  {{ page.note_semester }})</h1>
 
         <nav>
             <ul class="nav nav-tabs">


### PR DESCRIPTION
Fixed typo in *note.html* (there was **semestr** instead of **semester**).